### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ composer.phar
 composer.lock
 phpunit.xml
 mix-manifest.json
+yarn-error.log


### PR DESCRIPTION
Currently if Yarn errors then you get an untracked error log file. This shouldn't be tracked.